### PR TITLE
add extra security for granting permission to the web view

### DIFF
--- a/app/src/main/java/com/onfido/sdk/webviewandroid/PermissionHandlingWebChromeClient.kt
+++ b/app/src/main/java/com/onfido/sdk/webviewandroid/PermissionHandlingWebChromeClient.kt
@@ -17,6 +17,12 @@ internal class PermissionHandlingWebChromeClient(
     override fun getDefaultVideoPoster(): Bitmap = createBitmap(10, 10)
 
     override fun onPermissionRequest(request: PermissionRequest) {
+
+        if (request.origin.toString() != "https://sdk.onfido.com/") {
+            request.deny()
+            return
+        }
+
         val grants = mutableListOf<String>()
         val requiredPermissions = mutableListOf<String>()
         request.resources?.forEach { resource ->


### PR DESCRIPTION
Even, if we only load a page from the origin `sdk.onfido.com` and also the iframes are from this origin, it still makes sense to additional check the origin, before granting the requested permissions. 